### PR TITLE
Minor fix in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -184,7 +184,7 @@ Starmatrix includes a test suite located in the ``/src/starmatrix/tests`` direct
 
     $ git clone https://github.com/xuanxu/starmatrix.git
     $ cd starmatrix
-    $ pip install -e .[dev]
+    $ pip install -e ".[dev]"
     $ pytest -v --cov=starmatrix
 
 .. _`publicly tracked by GitHub CI`: https://github.com/xuanxu/starmatrix/actions/workflows/tests.yml


### PR DESCRIPTION
I added quotes around `.[dev]` because not adding them makes my terminal (zsh) treat it as a regex (I guess). I added quotations around `.[dev]` and ran the command in bash, csh, ksh, tcsh and zsh and all understand what I mean. So I assume this is probably generally working.