### PR TITLE
Aligning references

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -214,7 +214,7 @@ If you find a bug or have a question, please [open an issue in the project's rep
 
 Contributions are welcome, please read our `contributing guidelines`_.
 
-.. _`contributing guidelines`: https://github.com/xuanxu/starmatrix/blob/review/CONTRIBUTING.md
+.. _`contributing guidelines`: https://github.com/xuanxu/starmatrix/blob/main/CONTRIBUTING.md
 
 License
 =======


### PR DESCRIPTION
I reworded the references in the Supernova table so that they look the same as in the other tables. By doing that I noticed one thing you may want to fix: Some of the references lack page numbers (Gronow et al. 2021 could be two papers for instance). You may want to fix that too.